### PR TITLE
production build fixes

### DIFF
--- a/app/templates/app/_vendor.ts
+++ b/app/templates/app/_vendor.ts
@@ -10,6 +10,7 @@ import '@angular/router';
 import 'rxjs';
 
 //Alfresco
+import 'alfresco-js-api';
 import 'ng2-alfresco-core';
 import 'ng2-alfresco-datatable';
 import 'ng2-activiti-diagrams';
@@ -37,7 +38,7 @@ import '../public/css/app.css';
 import '../public/css/muli-font.css';
 
 // Load the Angular Material 2 stylesheet
-import '@angular/material/core/theming/prebuilt/deeppurple-amber.css'
+import '@angular/material/core/theming/prebuilt/deeppurple-amber.css';
 
 import 'ng2-activiti-form/stencils/runtime.ng1';
 import 'ng2-activiti-form/stencils/runtime.adf';
@@ -62,4 +63,7 @@ if (process.env.ENV === 'production') {
 }
 
 require('pdfjs-dist/web/pdf_viewer.js');
-require('three/build/three.min.js');
+
+// 3D viewer
+import 'three';
+import 'ng2-3d-editor';

--- a/app/templates/config/_webpack.prod.js
+++ b/app/templates/config/_webpack.prod.js
@@ -40,15 +40,15 @@ module.exports = webpackMerge(commonConfig, {
 
     // Reference: http://webpack.github.io/docs/list-of-plugins.html#uglifyjsplugin
     // Minify all javascript, switch loaders to minimizing mode
-    // new webpack.optimize.UglifyJsPlugin({
-    //   mangle: {
-    //     keep_fnames: true
-    //   },
-    //   compressor: {
-    //     screw_ie8: true,
-    //     warnings: false
-    //   }
-    // }),
+    new webpack.optimize.UglifyJsPlugin({
+      mangle: {
+        keep_fnames: true
+      },
+      compressor: {
+        screw_ie8: true,
+        warnings: false
+      }
+    }),
 
     // Extract css files
     // Reference: https://github.com/webpack/extract-text-webpack-plugin


### PR DESCRIPTION
refs https://github.com/Alfresco/alfresco-ng2-components/issues/1693

- enable minification (UglifyJsPlugin), requires alfresco-js-api 1.2.1
to be released
- add missing alfresco-js-api to the vendors
- add missing 3D viewer related libs to the vendors (fixes issue with
app bundle having duplicates)