### PR TITLE
[ADF-2125] Removed 'ng2-' from generator instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install -g yo
 Then the Alfresco Application Generator:
 
 ```sh
-npm install -g generator-ng2-alfresco-app
+npm install -g generator-alfresco-app
 ```
 
 ## Generating a new application project
@@ -33,7 +33,7 @@ npm install -g generator-ng2-alfresco-app
 First, move in the folder where you want create your project.
 
 ```sh
-yo ng2-alfresco-app
+yo alfresco-app
 ```
 
 You will need to run the following scripts in the generated folder:
@@ -48,21 +48,21 @@ Commands above install all project dependencies, start the project and watch for
 Alternatively you can use generator with install switch to trigger automatic installation of dependencies via npm install script:
 
 ```sh
-yo ng2-alfresco-app --install
+yo alfresco-app --install
 ```
 
 ## Updating generator
 
 ```sh
-npm update -g generator-ng2-alfresco-app
+npm update -g generator-alfresco-app
 ```
 
 ## Getting current version
 
-* Show current version generator-ng2-alfresco-app installed
+* Show current version generator-alfresco-app installed
 
 ```sh
-yo ng2-alfresco-app --version
+yo alfresco-app --version
 ```
 
 ## Contributing to the generator
@@ -96,10 +96,10 @@ Requirements for new projects:
 
 ```sh
 # OS X / Linux
-DEBUG=yeoman:generator yo ng2-alfresco-app
+DEBUG=yeoman:generator yo alfresco-app
 
 # Windows
-set DEBUG=yeoman:generator & yo ng2-alfresco-app
+set DEBUG=yeoman:generator & yo alfresco-app
 ```
 
 More on [debugging generators](http://yeoman.io/authoring/debugging.html).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm install -g yo
 Then the Alfresco Application Generator:
 
 ```sh
-npm install -g generator-alfresco-app
+npm install -g generator-alfresco-adf-app
 ```
 
 ## Generating a new application project
@@ -33,7 +33,7 @@ npm install -g generator-alfresco-app
 First, move in the folder where you want create your project.
 
 ```sh
-yo alfresco-app
+yo alfresco-adf-app
 ```
 
 You will need to run the following scripts in the generated folder:
@@ -48,21 +48,21 @@ Commands above install all project dependencies, start the project and watch for
 Alternatively you can use generator with install switch to trigger automatic installation of dependencies via npm install script:
 
 ```sh
-yo alfresco-app --install
+yo alfresco-adf-app --install
 ```
 
 ## Updating generator
 
 ```sh
-npm update -g generator-alfresco-app
+npm update -g generator-alfresco-adf-app
 ```
 
 ## Getting current version
 
-* Show current version generator-alfresco-app installed
+* Show current version generator-alfresco-adf-app installed
 
 ```sh
-yo alfresco-app --version
+yo alfresco-adf-app --version
 ```
 
 ## Contributing to the generator
@@ -96,10 +96,10 @@ Requirements for new projects:
 
 ```sh
 # OS X / Linux
-DEBUG=yeoman:generator yo alfresco-app
+DEBUG=yeoman:generator yo alfresco-adf-app
 
 # Windows
-set DEBUG=yeoman:generator & yo alfresco-app
+set DEBUG=yeoman:generator & yo alfresco-adf-app
 ```
 
 More on [debugging generators](http://yeoman.io/authoring/debugging.html).

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ yo alfresco-app --version
 6. Push to the branch: `git push origin my-new-feature`
 7. Submit a pull request
 
-> to Contribute to the existing code base Add test cases to cover the new behaviour, and make sure all the existing tests are still green.
+To Contribute to the existing code base, add test cases to cover the new behaviour, and make sure all the existing tests are still green.
 
 To test the generator:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ npm install -g yo
 Then the Alfresco Application Generator:
 
 ```sh
-npm install -g generator-alfresco-app
+npm install -g generator-alfresco-adf-app
 ```
 
 ## Generating a new application project
@@ -30,7 +30,7 @@ npm install -g generator-alfresco-app
 First, move in the folder where you want create your project.
 
 ```sh
-yo alfresco-app
+yo alfresco-adf-app
 ```
 
 You will need to run the following scripts in the generated folder:
@@ -45,21 +45,21 @@ Commands above install all project dependencies, start the project and watch for
 Alternatively you can use generator with install switch to trigger automatic installation of dependencies via npm install script:
 
 ```sh
-yo alfresco-app --install
+yo alfresco-adf-app --install
 ```
 
 ## Updating generator
 
 ```sh
-npm update -g generator-alfresco-app
+npm update -g generator-alfresco-adf-app
 ```
 
 ## Getting current version
 
-* Show current version generator-alfresco-app installed
+* Show current version generator-alfresco-adf-app installed
 
 ```sh
-yo alfresco-app --version
+yo alfresco-adf-app --version
 ```
 
 ## Contributing to the generator
@@ -98,10 +98,10 @@ If you want to create a new blueprint based on the existing git repository follo
 
 ```sh
 # OS X / Linux
-DEBUG=yeoman:generator yo alfresco-app
+DEBUG=yeoman:generator yo alfresco-adf-app
 
 # Windows
-set DEBUG=yeoman:generator & yo alfresco-app
+set DEBUG=yeoman:generator & yo alfresco-adf-app
 ```
 
 More on [debugging generators](http://yeoman.io/authoring/debugging.html).

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,8 @@ See the following [page](https://github.com/Alfresco/alfresco-ng2-components/blo
 
 ## Prerequisites
 
-<p class="warning">
 Before you start using this development framework and the generator, make sure you have installed all required software and done all the
 necessary configuration, see this [page](https://github.com/Alfresco/app-dev-framework/blob/master/PREREQUISITES.md).
-</p>
 
 ## Installing Yeoman and the App Generator
 
@@ -74,9 +72,7 @@ yo alfresco-app --version
 6. Push to the branch: `git push origin my-new-feature`
 7. Submit a pull request
 
-<p class="tip">
-To contribute to the existing code base Add test cases to cover the new behaviour, and make sure all the existing tests are still green.
-</p>
+To contribute to the existing code base, add test cases to cover the new behaviour, and make sure all the existing tests are still green.
 
 To test the generator:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ npm install -g yo
 Then the Alfresco Application Generator:
 
 ```sh
-npm install -g generator-ng2-alfresco-app
+npm install -g generator-alfresco-app
 ```
 
 ## Generating a new application project
@@ -32,7 +32,7 @@ npm install -g generator-ng2-alfresco-app
 First, move in the folder where you want create your project.
 
 ```sh
-yo ng2-alfresco-app
+yo alfresco-app
 ```
 
 You will need to run the following scripts in the generated folder:
@@ -47,21 +47,21 @@ Commands above install all project dependencies, start the project and watch for
 Alternatively you can use generator with install switch to trigger automatic installation of dependencies via npm install script:
 
 ```sh
-yo ng2-alfresco-app --install
+yo alfresco-app --install
 ```
 
 ## Updating generator
 
 ```sh
-npm update -g generator-ng2-alfresco-app
+npm update -g generator-alfresco-app
 ```
 
 ## Getting current version
 
-* Show current version generator-ng2-alfresco-app installed
+* Show current version generator-alfresco-app installed
 
 ```sh
-yo ng2-alfresco-app --version
+yo alfresco-app --version
 ```
 
 ## Contributing to the generator
@@ -102,10 +102,10 @@ If you want to create a new blueprint based on the existing git repository follo
 
 ```sh
 # OS X / Linux
-DEBUG=yeoman:generator yo ng2-alfresco-app
+DEBUG=yeoman:generator yo alfresco-app
 
 # Windows
-set DEBUG=yeoman:generator & yo ng2-alfresco-app
+set DEBUG=yeoman:generator & yo alfresco-app
 ```
 
 <p class="tip">

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,9 +108,7 @@ DEBUG=yeoman:generator yo alfresco-app
 set DEBUG=yeoman:generator & yo alfresco-app
 ```
 
-<p class="tip">
 More on [debugging generators](http://yeoman.io/authoring/debugging.html).
-</p>
 
 ## History
 


### PR DESCRIPTION
Removed the 'ng2-' bits from both README files. Also fixed some display errors caused by special <p> elements in the Markdown (they were stopping links from being shown correctly).