### PR TITLE
[hackathon] command line mode support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+sudo: required
 node_js:
   - "8"
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,28 @@ Alternatively you can use generator with install switch to trigger automatic ins
 yo alfresco-adf-app --install
 ```
 
+### Using from the command line
+
+You can use the generator in the unattended mode by providing all necessary options from the command line:
+
+```sh
+yo ng2-alfresco-app -n app2 -b adf-cli-aps-template -i
+```
+
+Options:
+
+| Name | Alias | Type | Description |
+| --- | --- | --- | --- |
+| --name=\<value> | -n \<value> | string | Application name |
+| --blueprint=\<value> | -b \<value> | string | Blueprint name |
+| --install | -i | boolean | Install dependencies upon generation |
+
+Default blueprint names:
+
+- adf-cli-acs-aps-template
+- adf-cli-acs-template
+- adf-cli-aps-template
+
 ## Updating generator
 
 ```sh

--- a/__tests__/app.js
+++ b/__tests__/app.js
@@ -10,7 +10,7 @@ describe('Alfresco component generator', () => {
       return helpers.run(path.join(__dirname, '../app'))
         .withPrompts({
           name: 'adf-cli-acs-template',
-          blueprint: 'Content Services'
+          blueprint: 'adf-cli-acs-template'
         });
     });
 
@@ -65,7 +65,7 @@ describe('Alfresco component generator', () => {
       return helpers.run(path.join(__dirname, '../app'))
         .withPrompts({
           name: 'adf-cli-aps-template',
-          blueprint: 'Process Services'
+          blueprint: 'adf-cli-aps-template'
         });
     });
 
@@ -124,7 +124,7 @@ describe('Alfresco component generator', () => {
       return helpers.run(path.join(__dirname, '../app'))
         .withPrompts({
           name: 'adf-cli-acs-aps-template',
-          blueprint: 'Process and Content Services'
+          blueprint: 'adf-cli-acs-aps-template'
         });
     });
 

--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,3 @@
-// const Generator = require('yeoman-generator');
 const utils = require('./utils');
 const alflogo = require('alfresco-logo');
 const CLIGenerator = require('generator-alfresco-common').cli_generator;
@@ -35,7 +34,6 @@ module.exports = class extends CLIGenerator {
         name: 'blueprint',
         message: 'Application blueprint',
         choices: this.blueprints.map(bp => {
-          // return bp.displayName;
           return {
             name: bp.displayName,
             value: bp.name

--- a/app/utils.js
+++ b/app/utils.js
@@ -23,7 +23,7 @@ class Utils {
     return json && json.name && json.version;
   }
 
-  async getBluprints() {
+  async getBlueprints() {
     const result = [];
     const dir = path.join(__dirname, 'templates');
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "alfresco-logo": "1.0.1",
+    "generator-alfresco-common": "0.9.25",
     "yeoman-generator": "2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Provides support for CLI (command line) mode

You can use the generator in the unattended mode by providing all necessary options from the command line:

```sh
yo ng2-alfresco-app -n app2 -b adf-cli-aps-template -i
```

Options:

| Name | Alias | Type | Description |
| --- | --- | --- | --- |
| --name=\<value> | -n \<value> | string | Application name |
| --blueprint=\<value> | -b \<value> | string | Blueprint name |
| --install | -i | boolean | Install dependencies upon generation |

Default blueprint names:

- adf-cli-acs-aps-template
- adf-cli-acs-template
- adf-cli-aps-template

Special thanks to @binduwavell for assistance and [generator-alfresco-common](https://github.com/binduwavell/generator-alfresco-common) project.