### PR TITLE
[ADF-2145] Add the app routes files in the generator 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+sudo: required
+dist: trusty
+addons:
+    chrome: stable
+before_script:
+    - "sudo chown root /opt/google/chrome/chrome-sandbox"
+    - "sudo chmod 4755 /opt/google/chrome/chrome-sandbox"
 language: node_js
 node_js:
   - "8"

--- a/app/templates/adf-cli-acs-aps-template/package.json
+++ b/app/templates/adf-cli-acs-aps-template/package.json
@@ -50,6 +50,7 @@
     "zone.js": "0.8.14"
   },
   "devDependencies": {
+    "@angular-devkit/core": "0.0.28",
     "@angular/cli": "1.5.0",
     "@angular/compiler-cli": "5.0.0",
     "@angular/language-service": "5.0.0",

--- a/app/templates/adf-cli-acs-aps-template/src/app/app.module.ts
+++ b/app/templates/adf-cli-acs-aps-template/src/app/app.module.ts
@@ -4,8 +4,6 @@ import { RouterModule, Routes } from '@angular/router';
 
 // ADF modules
 import { AdfModule } from './adf.module';
-import { AuthGuardBpm } from '@alfresco/adf-core';
-import { AuthGuardEcm } from '@alfresco/adf-core';
 
 // Custom stencils
 import { StencilsModule } from './stencils.module';
@@ -19,42 +17,7 @@ import { TasksComponent } from './tasks/tasks.component';
 import { TaskDetailsComponent } from './task-details/task-details.component';
 import { DocumentlistComponent } from './documentlist/documentlist.component';
 import { StartProcessComponent } from './start-process/start-process.component';
-
-const appRoutes: Routes = [
-  {
-    path: '',
-    component: HomeComponent
-  },
-  {
-    path: 'login',
-    component: LoginComponent
-  },
-  {
-    path: 'apps',
-    component: AppsComponent,
-    canActivate: [ AuthGuardBpm ]
-  },
-  {
-    path: 'apps/:appId/tasks',
-    component: TasksComponent,
-    canActivate: [ AuthGuardBpm ]
-  },
-  {
-    path: 'apps/:appId/tasks/:taskId',
-    component: TaskDetailsComponent,
-    canActivate: [ AuthGuardBpm ]
-  },
-  {
-    path: 'apps/:appId/start-process',
-    component: StartProcessComponent,
-    canActivate: [ AuthGuardBpm ]
-  },
-  {
-    path: 'documentlist',
-    component: DocumentlistComponent,
-    canActivate: [ AuthGuardEcm ]
-  }
-];
+import { appRoutes } from './app.routes';
 
 @NgModule({
   imports: [

--- a/app/templates/adf-cli-acs-aps-template/src/app/app.routes.ts
+++ b/app/templates/adf-cli-acs-aps-template/src/app/app.routes.ts
@@ -1,0 +1,66 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ModuleWithProviders } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard, AuthGuardBpm, AuthGuardEcm } from '@alfresco/adf-core';
+import { AppComponent } from './app.component';
+import { HomeComponent } from './home/home.component';
+import { LoginComponent } from './login/login.component';
+import { AppsComponent } from './apps/apps.component';
+import { TasksComponent } from './tasks/tasks.component';
+import { TaskDetailsComponent } from './task-details/task-details.component';
+import { DocumentlistComponent } from './documentlist/documentlist.component';
+import { StartProcessComponent } from './start-process/start-process.component';
+
+export const appRoutes: Routes = [
+  {
+    path: '',
+    component: HomeComponent
+  },
+  {
+    path: 'login',
+    component: LoginComponent
+  },
+  {
+    path: 'apps',
+    component: AppsComponent,
+    canActivate: [ AuthGuardBpm ]
+  },
+  {
+    path: 'apps/:appId/tasks',
+    component: TasksComponent,
+    canActivate: [ AuthGuardBpm ]
+  },
+  {
+    path: 'apps/:appId/tasks/:taskId',
+    component: TaskDetailsComponent,
+    canActivate: [ AuthGuardBpm ]
+  },
+  {
+    path: 'apps/:appId/start-process',
+    component: StartProcessComponent,
+    canActivate: [ AuthGuardBpm ]
+  },
+  {
+    path: 'documentlist',
+    component: DocumentlistComponent,
+    canActivate: [ AuthGuardEcm ]
+  }
+];
+
+export const routing: ModuleWithProviders = RouterModule.forRoot(appRoutes);

--- a/app/templates/adf-cli-acs-template/package.json
+++ b/app/templates/adf-cli-acs-template/package.json
@@ -48,6 +48,7 @@
     "zone.js": "0.8.14"
   },
   "devDependencies": {
+    "@angular-devkit/core": "0.0.28",
     "@angular/cli": "1.5.0",
     "@angular/compiler-cli": "5.0.0",
     "@angular/language-service": "5.0.0",

--- a/app/templates/adf-cli-acs-template/src/app/app.module.ts
+++ b/app/templates/adf-cli-acs-template/src/app/app.module.ts
@@ -13,21 +13,6 @@ import { HomeComponent } from './home/home.component';
 import { LoginComponent } from './login/login.component';
 import { DocumentlistComponent } from './documentlist/documentlist.component';
 
-const appRoutes: Routes = [
-  {
-    path: '',
-    component: HomeComponent
-  },
-  {
-    path: 'login',
-    component: LoginComponent
-  },
-  {
-    path: 'documentlist',
-    component: DocumentlistComponent,
-    canActivate: [ AuthGuardEcm ]
-  }
-];
 
 @NgModule({
   imports: [

--- a/app/templates/adf-cli-acs-template/src/app/app.module.ts
+++ b/app/templates/adf-cli-acs-template/src/app/app.module.ts
@@ -1,11 +1,10 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { appRoutes } from './app.routes';
 
 // ADF modules
 import { AdfModule } from './adf.module';
-import { AuthGuardBpm } from '@alfresco/adf-core';
-import { AuthGuardEcm } from '@alfresco/adf-core';
 
 
 // App components

--- a/app/templates/adf-cli-acs-template/src/app/app.routes.ts
+++ b/app/templates/adf-cli-acs-template/src/app/app.routes.ts
@@ -1,0 +1,42 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ModuleWithProviders } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard, AuthGuardBpm, AuthGuardEcm } from '@alfresco/adf-core';
+import { AppComponent } from './app.component';
+import { HomeComponent } from './home/home.component';
+import { LoginComponent } from './login/login.component';
+import { DocumentlistComponent } from './documentlist/documentlist.component';
+
+export const appRoutes: Routes = [
+  {
+    path: '',
+    component: HomeComponent
+  },
+  {
+    path: 'login',
+    component: LoginComponent
+  },
+  {
+    path: 'documentlist',
+    component: DocumentlistComponent,
+    canActivate: [ AuthGuardEcm ]
+  }
+];
+
+export const routing: ModuleWithProviders = RouterModule.forRoot(appRoutes);

--- a/app/templates/adf-cli-aps-template/package.json
+++ b/app/templates/adf-cli-aps-template/package.json
@@ -50,6 +50,7 @@
     "zone.js": "0.8.14"
   },
   "devDependencies": {
+    "@angular-devkit/core": "0.0.28",
     "@angular/cli": "1.5.0",
     "@angular/compiler-cli": "5.0.0",
     "@angular/language-service": "5.0.0",

--- a/app/templates/adf-cli-aps-template/src/app/app.module.ts
+++ b/app/templates/adf-cli-aps-template/src/app/app.module.ts
@@ -19,36 +19,7 @@ import { TasksComponent } from './tasks/tasks.component';
 import { TaskDetailsComponent } from './task-details/task-details.component';
 import { StartProcessComponent } from './start-process/start-process.component';
 
-const appRoutes: Routes = [
-  {
-    path: '',
-    component: HomeComponent
-  },
-  {
-    path: 'login',
-    component: LoginComponent
-  },
-  {
-    path: 'apps',
-    component: AppsComponent,
-    canActivate: [ AuthGuardBpm ]
-  },
-  {
-    path: 'apps/:appId/tasks',
-    component: TasksComponent,
-    canActivate: [ AuthGuardBpm ]
-  },
-  {
-    path: 'apps/:appId/tasks/:taskId',
-    component: TaskDetailsComponent,
-    canActivate: [ AuthGuardBpm ]
-  },
-  {
-    path: 'apps/:appId/start-process',
-    component: StartProcessComponent,
-    canActivate: [ AuthGuardBpm ]
-  }
-];
+import { appRoutes } from './app.routes';
 
 @NgModule({
   imports: [

--- a/app/templates/adf-cli-aps-template/src/app/app.routes.ts
+++ b/app/templates/adf-cli-aps-template/src/app/app.routes.ts
@@ -1,0 +1,60 @@
+/*!
+ * @license
+ * Copyright 2016 Alfresco Software, Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ModuleWithProviders } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard, AuthGuardBpm, AuthGuardEcm } from '@alfresco/adf-core';
+import { AppComponent } from './app.component';
+import { HomeComponent } from './home/home.component';
+import { LoginComponent } from './login/login.component';
+import { AppsComponent } from './apps/apps.component';
+import { TasksComponent } from './tasks/tasks.component';
+import { TaskDetailsComponent } from './task-details/task-details.component';
+import { StartProcessComponent } from './start-process/start-process.component';
+
+export const appRoutes: Routes = [
+  {
+    path: '',
+    component: HomeComponent
+  },
+  {
+    path: 'login',
+    component: LoginComponent
+  },
+  {
+    path: 'apps',
+    component: AppsComponent,
+    canActivate: [ AuthGuardBpm ]
+  },
+  {
+    path: 'apps/:appId/tasks',
+    component: TasksComponent,
+    canActivate: [ AuthGuardBpm ]
+  },
+  {
+    path: 'apps/:appId/tasks/:taskId',
+    component: TaskDetailsComponent,
+    canActivate: [ AuthGuardBpm ]
+  },
+  {
+    path: 'apps/:appId/start-process',
+    component: StartProcessComponent,
+    canActivate: [ AuthGuardBpm ]
+  }
+];
+
+export const routing: ModuleWithProviders = RouterModule.forRoot(appRoutes);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-ng2-alfresco-app",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "ADF application generator for Yeoman",
   "author": "Alfresco Software, Ltd.",
   "main": "app/index.js",


### PR DESCRIPTION
The routes file help to have a better separation of concern when you generate an empty project with the generator