### PR TITLE
[ADF-2424] reduce docker image sizes

### DIFF
--- a/app/templates/adf-cli-acs-aps-template/Dockerfile
+++ b/app/templates/adf-cli-acs-aps-template/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 

--- a/app/templates/adf-cli-acs-template/Dockerfile
+++ b/app/templates/adf-cli-acs-template/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 

--- a/app/templates/adf-cli-aps-template/Dockerfile
+++ b/app/templates/adf-cli-aps-template/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/nginx.conf
 


### PR DESCRIPTION
Switch to `nginx:alpine` to reduce resulting image sizes to approx 15 mb (from 51 mb)