### PR TITLE
remove workaround for 1.6.x

### DIFF
--- a/app/templates/adf-cli-acs-aps-template/package.json
+++ b/app/templates/adf-cli-acs-aps-template/package.json
@@ -54,7 +54,6 @@
     "zone.js": "0.8.14"
   },
   "devDependencies": {
-    "@angular-devkit/core": "0.0.28",
     "@angular/cli": "1.7.3",
     "@angular/compiler-cli": "^5.2.0",
     "@angular/language-service": "^5.2.0",

--- a/app/templates/adf-cli-acs-template/package.json
+++ b/app/templates/adf-cli-acs-template/package.json
@@ -52,7 +52,6 @@
     "zone.js": "0.8.14"
   },
   "devDependencies": {
-    "@angular-devkit/core": "0.0.28",
     "@angular/cli": "1.7.3",
     "@angular/compiler-cli": "^5.2.0",
     "@angular/language-service": "^5.2.0",

--- a/app/templates/adf-cli-aps-template/package.json
+++ b/app/templates/adf-cli-aps-template/package.json
@@ -54,7 +54,6 @@
     "zone.js": "0.8.14"
   },
   "devDependencies": {
-    "@angular-devkit/core": "0.0.28",
     "@angular/cli": "1.7.3",
     "@angular/compiler-cli": "^5.2.0",
     "@angular/language-service": "^5.2.0",


### PR DESCRIPTION
remove old workaround with adding/pinning the version of "@angular-devkit/core". It is not needed to be in package.json with 1.7.x and prevents CLI commands from execution if left there.