### PR TITLE
Fix adf-core i18n are not loaded in 2.5.0

### DIFF
--- a/app/templates/adf-cli-acs-aps-template/src/app/app.component.ts
+++ b/app/templates/adf-cli-acs-aps-template/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { ViewEncapsulation, Component } from '@angular/core';
-import { TranslationService, AuthenticationService } from '@alfresco/adf-core';
+import { AuthenticationService } from '@alfresco/adf-core';
 import { Router } from '@angular/router';
 
 @Component({
@@ -10,10 +10,8 @@ import { Router } from '@angular/router';
 })
 export class AppComponent {
 
-  constructor(translationService: TranslationService,
-              private authService: AuthenticationService,
+  constructor(private authService: AuthenticationService,
               private router: Router) {
-    translationService.use('en');
   }
 
   logout() {

--- a/app/templates/adf-cli-acs-template/src/app/app.component.ts
+++ b/app/templates/adf-cli-acs-template/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-import { TranslationService, AuthenticationService } from '@alfresco/adf-core';
+import { AuthenticationService } from '@alfresco/adf-core';
 import { Router } from '@angular/router';
 
 @Component({
@@ -10,10 +10,8 @@ import { Router } from '@angular/router';
 })
 export class AppComponent {
 
-  constructor(translationService: TranslationService,
-              private authService: AuthenticationService,
+  constructor(private authService: AuthenticationService,
               private router: Router) {
-    translationService.use('en');
   }
 
   logout() {

--- a/app/templates/adf-cli-aps-template/src/app/app.component.ts
+++ b/app/templates/adf-cli-aps-template/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component, ViewEncapsulation } from '@angular/core';
-import { TranslationService, AuthenticationService } from '@alfresco/adf-core';
+import { AuthenticationService } from '@alfresco/adf-core';
 import { Router } from '@angular/router';
 
 @Component({
@@ -10,10 +10,8 @@ import { Router } from '@angular/router';
 })
 export class AppComponent {
 
-  constructor(translationService: TranslationService,
-              private authService: AuthenticationService,
+  constructor(private authService: AuthenticationService,
               private router: Router) {
-    translationService.use('en');
   }
 
   logout() {


### PR DESCRIPTION
This is a regression from 2.4.0 to 2.5.0

By setting a default language on translationService, this is overriding adf-core i18n translations loaded by CoreModule. Thus, there are no label displayed for adf-core components.

Note that adf-content-services or adf-process-services i18n were loading fine though using TRANSLATION_PROVIDER.

Regards

Nicolas