### PR TITLE
Fixed typo with Application name in following templates: adf-cli-acs-aps-template, adf-cli-acs-template, adf-cli-aps-template

### DIFF
--- a/app/templates/adf-cli-acs-aps-template/src/app.config.json
+++ b/app/templates/adf-cli-acs-aps-template/src/app.config.json
@@ -4,7 +4,7 @@
     "bpmHost": "http://{hostname}{:port}",
     "providers" : "ALL",
     "application": {
-        "name": "Alfresco ADF Appplication"
+        "name": "Alfresco ADF Application"
     },
     "languages": [
         {

--- a/app/templates/adf-cli-acs-template/src/app.config.json
+++ b/app/templates/adf-cli-acs-template/src/app.config.json
@@ -4,7 +4,7 @@
     "bpmHost": "http://{hostname}{:port}",
     "providers" : "ECM",
     "application": {
-        "name": "Alfresco ADF Appplication"
+        "name": "Alfresco ADF Application"
     },
     "languages": [
         {

--- a/app/templates/adf-cli-aps-template/src/app.config.json
+++ b/app/templates/adf-cli-aps-template/src/app.config.json
@@ -4,7 +4,7 @@
     "bpmHost": "http://{hostname}{:port}",
     "providers" : "BPM",
     "application": {
-        "name": "Alfresco ADF Appplication"
+        "name": "Alfresco ADF Application"
     },
     "languages": [
         {


### PR DESCRIPTION
- adf-cli-acs-aps-template
- adf-cli-acs-template
- adf-cli-aps-template