### PR TITLE
[ADF-4353] Fix templates and update tab title

### DIFF
--- a/app/templates/adf-cli-acs-aps-template/package.json
+++ b/app/templates/adf-cli-acs-aps-template/package.json
@@ -20,6 +20,7 @@
     "@alfresco/adf-content-services": "3.1.0",
     "@alfresco/adf-process-services": "3.1.0",
     "@alfresco/adf-insights": "3.1.0",
+    "@alfresco/adf-extensions": "3.1.0",
     "@alfresco/js-api": "3.1.0",
     "@angular/animations": "7.0.3",
     "@angular/cdk": "7.0.3",

--- a/app/templates/adf-cli-acs-aps-template/src/index.html
+++ b/app/templates/adf-cli-acs-aps-template/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>ACS APS ADF Application with Angular CLI</title>
+  <title>ACS APS ADF Application</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/templates/adf-cli-acs-template/package.json
+++ b/app/templates/adf-cli-acs-template/package.json
@@ -19,6 +19,7 @@
     "@alfresco/adf-core": "3.1.0",
     "@alfresco/adf-content-services": "3.1.0",
     "@alfresco/js-api": "3.1.0",
+    "@alfresco/adf-extensions": "3.1.0",
     "@angular/animations": "7.0.3",
     "@angular/cdk": "7.0.3",
     "@angular/common": "7.0.3",

--- a/app/templates/adf-cli-acs-template/src/index.html
+++ b/app/templates/adf-cli-acs-template/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>ACS ADF Application with Angular CLI</title>
+  <title>ACS ADF Application</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/templates/adf-cli-activiti-acs-template/package.json
+++ b/app/templates/adf-cli-activiti-acs-template/package.json
@@ -20,6 +20,7 @@
     "@alfresco/adf-content-services": "3.1.0",
     "@alfresco/adf-process-services-cloud": "3.1.0",
     "@alfresco/adf-insights": "3.1.0",
+    "@alfresco/adf-extensions": "3.1.0",
     "@alfresco/js-api": "3.1.0",
     "@angular/animations": "7.0.3",
     "@angular/cdk": "7.0.3",

--- a/app/templates/adf-cli-activiti-acs-template/src/app/tasks/tasks.component.html
+++ b/app/templates/adf-cli-activiti-acs-template/src/app/tasks/tasks.component.html
@@ -1,6 +1,6 @@
 <h3>Tasks > {{ appName }}</h3>
 
-<button 
+<button
     *ngIf="appName"
     mat-raised-button
     routerLink="/apps/{{appName}}/start-process"
@@ -9,6 +9,6 @@
 </button>
 
 <adf-cloud-task-list
-    [applicationName]="appName"
+    [appName]="appName"
     (rowClick)="onRowClick($event)">
 </adf-cloud-task-list>

--- a/app/templates/adf-cli-activiti-acs-template/src/index.html
+++ b/app/templates/adf-cli-activiti-acs-template/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>APS ADF Application with Angular CLI</title>
+  <title>Activiti & ACS ADF Application</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/templates/adf-cli-activiti-template/package.json
+++ b/app/templates/adf-cli-activiti-template/package.json
@@ -20,6 +20,7 @@
     "@alfresco/adf-core": "3.1.0",
     "@alfresco/adf-insights": "3.1.0",
     "@alfresco/adf-process-services-cloud": "3.1.0",
+    "@alfresco/adf-extensions": "3.1.0",
     "@alfresco/js-api": "3.1.0",
     "@angular/animations": "7.0.3",
     "@angular/cdk": "7.0.3",

--- a/app/templates/adf-cli-activiti-template/src/app/tasks/tasks.component.html
+++ b/app/templates/adf-cli-activiti-template/src/app/tasks/tasks.component.html
@@ -1,6 +1,6 @@
 <h3>Tasks > {{ appName }}</h3>
 
-<button 
+<button
     *ngIf="appName"
     mat-raised-button
     routerLink="/apps/{{appName}}/start-process"
@@ -9,6 +9,6 @@
 </button>
 
 <adf-cloud-task-list
-    [applicationName]="appName"
+    [appName]="appName"
     (rowClick)="onRowClick($event)">
 </adf-cloud-task-list>

--- a/app/templates/adf-cli-activiti-template/src/index.html
+++ b/app/templates/adf-cli-activiti-template/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>APS ADF Application with Angular CLI</title>
+  <title>Activiti ADF Application</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/templates/adf-cli-aps-template/package.json
+++ b/app/templates/adf-cli-aps-template/package.json
@@ -20,6 +20,7 @@
     "@alfresco/adf-content-services": "3.1.0",
     "@alfresco/adf-process-services": "3.1.0",
     "@alfresco/adf-insights": "3.1.0",
+    "@alfresco/adf-extensions": "3.1.0",
     "@alfresco/js-api": "3.1.0",
     "@angular/animations": "7.0.3",
     "@angular/cdk": "7.0.3",

--- a/app/templates/adf-cli-aps-template/src/index.html
+++ b/app/templates/adf-cli-aps-template/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>APS ADF Application with Angular CLI</title>
+  <title>APS ADF Application</title>
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
Added adf-extensions package was missing from the different templates.
Task List Cloud component property binfing fix.
Tab titles updated for the different templates.

https://issues.alfresco.com/jira/browse/ADF-4353