### PR TITLE
Add missing i18n properties in ja.json file.

### DIFF
--- a/app/templates/adf-cli-acs-template/resources/i18n/ja.json
+++ b/app/templates/adf-cli-acs-template/resources/i18n/ja.json
@@ -100,6 +100,7 @@
   "DOCUMENT_LIST": {
     "MULTISELECT_CHECKBOXES": "複数選択 (チェックボックスを使用)",
     "THUMBNAILS": "サムネイルを有効にする",
+    "ALLOW_DROP_FILES": "フォルダー内のドロップファイルを有効にする",
     "MULTIPLE_FILE_UPLOAD": "複数ファイルのアップロード",
     "FOLDER_UPLOAD": "フォルダのアップロード",
     "CUSTOM_FILTER": "カスタム拡張子フィルタ",
@@ -118,6 +119,7 @@
       "DISPLAY_NAME": "表示名",
       "IS_LOCKED": "ロック",
       "TAG": "タグ",
+      "NODE_ID": "ノード ID",
       "CREATED_BY": "作成者",
       "CREATED_ON": "作成日",
       "CREATED": "作成日",


### PR DESCRIPTION
Hi.

Among the files under the i18n directory, there were properties that were in en.json but not in ja.json.

How about it?